### PR TITLE
Improvements, bugfixes and code cleanup

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -368,7 +368,7 @@ public class M75GetNotePatch
 [HarmonyPatch(typeof(EvidenceFingerprint), "GetNameForDataKey")]
 public class M75GetNameForDataKeyPatch
 {
-    public static string Postfix(EvidenceFingerprint __instance)
+    public static string Postfix(string __result, EvidenceFingerprint __instance, Il2CppSystem.Collections.Generic.List<Evidence.DataKey> inputKeys)
     {
         // Fingerprint evidence notes are always partial, this is the title of the window
         return $"Fingerprint ({PartialPrints.GetPrintPartial((uint)__instance.writer.humanID, __instance.evID)})";

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -396,6 +396,39 @@ public class M75EvidenceFingerprintControllerPatch
 
 #endregion
 
+#region Patch: GameplayController.AddNewMatch
+
+[HarmonyPatch(typeof(GameplayController), "AddNewMatch")]
+public class M75FactMatchesPatch
+{
+    // Makes it so that fingerprints don't auto connect facts.
+    public static bool Prefix(MatchPreset match, Evidence newEntry)
+    {
+        // If we've already processed it, ignore it.
+        if (PartialPrints.ProcessedMatchPresets.Contains(match))
+        {
+            return true;
+        }
+
+        for (int i = match.matchConditions.Count - 1; i >= 0; --i)
+        {
+            if (match.matchConditions._items[i] == MatchPreset.MatchCondition.fingerprint)
+            {
+                // We technically want to remove this, but the default if no conditions are present is to match. So instead, we change it to visualDescriptors.
+                // This will attempt to cast the EvidenceFingerprint to an EvidenceCitizen, fail, and return false...which is our end goal. It's a roundabout way to what we want.
+                match.matchConditions._items[i] = MatchPreset.MatchCondition.visualDescriptors;
+                //SOD.Common.Plugin.Log.LogInfo("Visualdescriptor");
+            }
+        }
+
+        // Keep track of what we've processed.
+        PartialPrints.ProcessedMatchPresets.Add(match);
+        return true;
+    }
+}
+
+#endregion
+
 #region Additional Structures
 
 public class ConfigEntryCache<T>


### PR DESCRIPTION
# Bugfixes
- No longer shows a "BelongsTo" connection to the citizen the partial print belongs to on the partial print evidence note
- No longer ticks the checkbox for fingerprint on the owner of the partial print when a partial print is scanned/added to caseboard

# Improvements
- Cleaned up the overview / information shown on the fingerprint note
- Adjusted the title of the evidence note to make more sense
- Used more general code from SOD.Common to improve readability.

# Removal
- Removed the configuration option to show the belongs to person as it counters directly the mod purpose.